### PR TITLE
Upgrade Fixie to 3.0.0-beta.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fixie.console": {
-      "version": "3.0.0-alpha.3",
+      "version": "3.0.0-beta.1",
       "commands": [
         "fixie"
       ]

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 ﻿The MIT License (MIT)
-Copyright © 2019-2020 Patrick Lioi
+Copyright © 2019-2021 Patrick Lioi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <FixieVersion>3.0.0-alpha.3</FixieVersion>
+        <FixieVersion>3.0.0-beta.1</FixieVersion>
         <xUnitVersion>2.4.1</xUnitVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
### build.cmd  test after upgrading.

```
 .\build.cmd

dotnet --version

3.1.406

dotnet tool restore

Tool 'fixie.console' (version '3.0.0-beta.1') was restored. Available commands: fixie

Restore was successful.

dotnet clean src -c $configuration --nologo -v minimal


dotnet build src -c $configuration --nologo

  Determining projects to restore...
  Restored H:\open-source\fixie.benchmark\src\CodeGeneration\CodeGeneration.csproj (in 166 ms).
  Restored H:\open-source\fixie.benchmark\src\Fixie.Tests\Fixie.Tests.csproj (in 267 ms).
  Restored H:\open-source\fixie.benchmark\src\xUnit.Tests\xUnit.Tests.csproj (in 412 ms).
  CodeGeneration -> H:\open-source\fixie.benchmark\src\CodeGeneration\bin\Release\netcoreapp3.1\CodeGeneration.dll
  xUnit.Tests -> H:\open-source\fixie.benchmark\src\xUnit.Tests\bin\Release\netcoreapp3.1\xUnit.Tests.dll
  Fixie.Tests -> H:\open-source\fixie.benchmark\src\Fixie.Tests\bin\Release\netcoreapp3.1\Fixie.Tests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:02.99

dotnet fixie Fixie.Tests -c $configuration --no-build

Running Fixie.Tests

25000 passed, took 0.78 seconds


dotnet test src/xUnit.Tests -c $configuration --no-build

Test run for H:\open-source\fixie.benchmark\src\xUnit.Tests\bin\Release\netcoreapp3.1\xUnit.Tests.dll(.NETCoreApp,Version=v3.1)
Microsoft (R) Test Execution Command Line Tool Version 16.7.1
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

A total of 1 test files matched the specified pattern.

Test Run Successful.
Total tests: 25000
     Passed: 25000
 Total time: 4.5744 Seconds

Build Succeeded
```

### visual studio test runner after upgrading.
`25000 passed, took 1.41 seconds`
